### PR TITLE
Fix 'non-well formed number notice' issue

### DIFF
--- a/server/php/UploadHandler.php
+++ b/server/php/UploadHandler.php
@@ -356,15 +356,23 @@ class UploadHandler
     }
 
     public function get_config_bytes($val) {
-        $val = trim($val);
-        $last = strtolower($val[strlen($val)-1]);
-        $val = (int)$val;
-        switch ($last) {
+        $str = trim($val);
+        $last = strtolower($str[strlen($str)-1]);
+        $val;
+        if(is_numeric($last)) {
+            $val = (int) $str;
+        } else {
+            $val = (int) substr($str, 0, -1);
+        }
+        switch($last) {
             case 'g':
+            case 'G':
                 $val *= 1024;
             case 'm':
+            case 'M':
                 $val *= 1024;
             case 'k':
+            case'K':
                 $val *= 1024;
         }
         return $this->fix_integer_overflow($val);


### PR DESCRIPTION
On PHP 7.0, I got the following notice while uploading a file:

`Notice: A non well formed numeric value encountered in UploadHandler.php on line 364`

The upload succeeded, but since the error messages are returned the JSON couldn't be parsed.

Refer to this discussion for more details:
https://github.com/FineUploader/php-traditional-server/issues/18